### PR TITLE
Reduce Z Homing Speed for PZ Probes

### DIFF
--- a/probes/e3d_pz_probe__btt_sb2209_usb.cfg
+++ b/probes/e3d_pz_probe__btt_sb2209_usb.cfg
@@ -33,3 +33,4 @@ zero_reference_position: 38.6, 11.5
 
 [stepper_z]
 endstop_pin: probe:z_virtual_endstop
+homing_speed: 7

--- a/probes/e3d_pz_probe__ldo_nitehawk_sb.cfg
+++ b/probes/e3d_pz_probe__ldo_nitehawk_sb.cfg
@@ -33,3 +33,4 @@ zero_reference_position: 38.6, 11.5
 
 [stepper_z]
 endstop_pin: probe:z_virtual_endstop
+homing_speed: 7


### PR DESCRIPTION
From the discussion in #3, on my configuration with the E3D PZ, I reduced `stepper_z homing_speed` from the default 35 to 7. With the values being very different from the `probe horizontal_move_z`, the same sensitivity can't be used reliably between homing and bed mesh. 7 has reliably worked for me with a few dozen bed meshes.