### PR TITLE
Reduce Default BTT SKR Mini E3 SGTHRS Values

### DIFF
--- a/mainboards/btt_skr_mini_e3_v3.cfg
+++ b/mainboards/btt_skr_mini_e3_v3.cfg
@@ -29,7 +29,7 @@ diag_pin: ^PC0
 uart_address: 0
 uart_pin: PC11
 tx_pin: PC10
-driver_SGTHRS: 141
+driver_SGTHRS: 135
 
 [stepper_y]
 microsteps: 16
@@ -51,7 +51,7 @@ diag_pin: ^PC1
 uart_address: 2
 uart_pin: PC11
 tx_pin: PC10
-driver_SGTHRS: 141
+driver_SGTHRS: 135
 
 [stepper_z]
 microsteps: 16
@@ -74,7 +74,7 @@ diag_pin: ^PC2
 uart_address: 1
 uart_pin: PC11
 tx_pin: PC10
-driver_SGTHRS: 141
+driver_SGTHRS: 135
 
 [static_digital_output status_led]
 pins: PD8


### PR DESCRIPTION
The default 141 values were found experimentally before on Discord before, but in long-term testing, they were only about 80% reliable. 137 was almost perfect (only 1 homing failure in many dozen homings), so 135 is *probably* safe. The values might be a bit belt tension-dependent.