### PR TITLE
Attempt at adding a sample config for BTT SB2209 CAN toolboard

### DIFF
--- a/printer.cfg.example
+++ b/printer.cfg.example
@@ -44,6 +44,13 @@ enable_force_move: True
 #[mcu sb2209]
 #serial: /dev/serial/by-id/usb-Klipper_rp2040_xxxxxxx
 
+##### BTT SBB2209 CAN
+#[include prusawire/toolboards/btt_sb2209_can.cfg]
+#
+#[mcu sb2209can]
+#serial: /dev/serial/by-id/usb-Klipper_Klipper_firmware_xxxx
+#canbus_uuid: 0e0d81e4210c
+
 #########################
 #### PROBES
 

--- a/printer.cfg.example
+++ b/printer.cfg.example
@@ -66,6 +66,9 @@ enable_force_move: True
 ##### SuperPINDA on BTT SB2209 USB
 #[include prusawire/probes/super_pinda__btt_sb2209_usb.cfg]
 
+##### SuperPINDA on BTT SB2209 CAN
+#[include prusawire/probes/super_pinda__btt_sb2209_can.cfg]
+
 ##### E3D PZ Probe on BTT SB2209 USB
 #[include prusawire/probes/e3d_pz_probe__btt_sb2209_usb.cfg]
 

--- a/probes/super_pinda__btt_sb2209_can.cfg
+++ b/probes/super_pinda__btt_sb2209_can.cfg
@@ -1,0 +1,52 @@
+[probe]
+pin: ^EBBCan: PC13
+x_offset: 38.6
+y_offset: 0.0
+samples: 3
+samples_result: average
+samples_tolerance: 0.05
+samples_tolerance_retries: 5
+sample_retract_dist: 0.5
+deactivate_on_each_sample: False
+speed: 8
+lift_speed: 8
+
+[bed_mesh]
+speed: 300
+horizontal_move_z: 4
+mesh_min: 38.605, 11.5
+mesh_max: 247.1, 203.0
+probe_count: 7, 7
+algorithm: bicubic
+fade_start: 1
+fade_end: 10
+fade_target: 0
+mesh_pps: 3, 3
+zero_reference_position: 38.6, 11.5
+faulty_region_1_min: 0.0, 1.0
+faulty_region_1_max: 24.0, 100.0
+faulty_region_2_min: 26.0, -18.0
+faulty_region_2_max: 97.0, 4.0
+faulty_region_3_min: 159.0, -18.0
+faulty_region_3_max: 231.0, 4.0
+faulty_region_4_min: 131.0, -15.0
+faulty_region_4_max: 149.0, 26.0
+faulty_region_5_min: 198.0, 10.0
+faulty_region_5_max: 235.0, 27.0
+faulty_region_6_min: 238.0, 26.0
+faulty_region_6_max: 255.0, 99.0
+faulty_region_7_min: 120.0, 43.0
+faulty_region_7_max: 138.0, 83.0
+faulty_region_8_min: 211.0, 95.0
+faulty_region_8_max: 230.0, 129.0
+faulty_region_9_min: 161.0, 102.0
+faulty_region_9_max: 197.0, 118.0
+faulty_region_10_min: 63.0, 102.0
+faulty_region_10_max: 97.0, 118.0
+faulty_region_11_min: 29.0, 95.0
+faulty_region_11_max: 44.0, 129.0
+faulty_region_12_min: 238.0, 122.0
+faulty_region_12_max: 255.0, 191.0
+
+[stepper_z]
+endstop_pin: probe:z_virtual_endstop

--- a/probes/super_pinda__btt_sb2209_can.cfg
+++ b/probes/super_pinda__btt_sb2209_can.cfg
@@ -1,5 +1,5 @@
 [probe]
-pin: ^EBBCan: PC13
+pin: ^sb2209can:PC13
 x_offset: 38.6
 y_offset: 0.0
 samples: 3

--- a/toolboards/btt_sb2209_can.cfg
+++ b/toolboards/btt_sb2209_can.cfg
@@ -1,0 +1,63 @@
+# "sb2209can" for the CANBus pin names comes from the "[mcu sb2209can]" config section in printer.cfg.
+#     If you chance that name, change the pin names here to match.
+# reference information derived from: https://github.com/bigtreetech/EBB/blob/master/EBB%20SB2240_2209%20CAN/sample-bigtreetech-ebb-sb-canbus-v1.0.cfg
+# and https://bttwiki.com/EBB%202240%202209%20CAN.html
+[temperature_sensor SB2209_USB]
+sensor_type: Generic 3950
+sensor_pin: sb2209can:PA2       # confirm pin name with your setup
+
+[adxl345]
+cs_pin: sb2209can:PB12
+spi_software_sclk_pin: sb2209can:PB10
+spi_software_mosi_pin: sb2209can:PB11
+spi_software_miso_pin: sb2209:PB2
+axes_map: z,-y,x
+
+[resonance_tester]
+probe_points: 100, 100, 20
+accel_chip: adxl345
+
+[extruder]
+step_pin: sb2209can:PD0		    # confirm pin name with your setup
+dir_pin: !sb2209can:PD1		    # confirm pin name with your setup
+enable_pin: !sb2209can:PD2		# confirm pin name with your setup
+filament_diameter: 1.750
+heater_pin: sb2209can:PB13		# confirm pin name with your setup
+pullup_resistor: 2200
+sensor_pin: sb2209can:PA3		# confirm pin name with your setup
+
+[tmc2209 extruder]
+uart_pin: sb2209can:PA15 		# confirm pin name with your setup
+run_current: 0.46
+stealthchop_threshold: 7
+driver_TBL: 2
+driver_TOFF: 4
+driver_HSTRT: 3
+driver_HEND: 4
+driver_TPOWERDOWN: 0
+coolstep_threshold: 30
+driver_PWM_GRAD: 4
+driver_PWM_FREQ: 0
+driver_PWM_AUTOSCALE: True
+driver_FREEWHEEL: 1
+
+[heater_fan hotend_fan]
+pin: sb2209can:PA0			    # confirm pin name with your setup
+tachometer_pin: sb2209can:PB15	# confirm pin name with your setup
+tachometer_ppr: 2
+tachometer_poll_interval: 0.0015
+heater: extruder
+heater_temp: 50.0
+
+[fan]
+pin: sb2209can:PA0		        # confirm pin name with your setup
+# max_power: 0.8
+
+[neopixel Stealthburner]
+pin: sb2209can:PD3			    # confirm pin name with your setup
+color_order: GRBW
+chain_count: 3
+initial_RED: 0.0
+initial_GREEN: 0.0
+initial_BLUE: 0.00
+initial_WHITE: 0.1


### PR DESCRIPTION
This is untested, but maybe it will be useful to others!

- Added commented out toolboard include and probe include in printer.cfg.example
- Added sample SuperPINDA probe config
- Added sample BTT SB2209 CAN board config

Feedback from actual hardware testers would be appreciated!