### PR TITLE
Config file for using SuperPINDA together with Einsy Rambo + drop bad_region entries and tweak start and end position to avoid magnets through the power of math

### DIFF
--- a/probes/super_pinda__einsy_rambo.cfg
+++ b/probes/super_pinda__einsy_rambo.cfg
@@ -14,6 +14,14 @@ lift_speed: 25
 [bed_mesh]
 speed: 300
 horizontal_move_z: 4
+# The following mesh_min and mesh_max values are only tested on the 2025.B1
+# release using the Stealthburner and Pinda mount from Printables on a MK52
+# heated bed. After noting that the stock Prusa MK2/3 firmware only defines
+# three bad spots for a whole 7x7 bed probe, these outer bounds were found
+# to avoid every single magnet for 3x3, 5x5 and 7x7 probing. This is done
+# at the cost of not probing a big chunk along the left side (where the 
+# SuperPINDA can't reach anyway), and a good bit on the right and the top
+# of the bed. In return you get a very fast and consistent bed mesh.
 mesh_min: 55, 11.5
 mesh_max: 240, 194.0
 probe_count: 7, 7


### PR DESCRIPTION
This is my config that finally got the SuperPINDA working reliably for me. I moved it to the factory default probe pins on the Einsy Rambo, but I also removed all the bad regions and tweaked the mesh_min and mesh_max values so that all the auto calculated probe points for 3x3, 5x5 and 7x7 probing will miss the magnets. The final change is to tweak the speed of the probing, as the default values was making my steppers squeak.

As this is a three-in-one patch I wasn't sure what to do, I can distribute the changes to their respective files if that is better.