### PR TITLE
Fix incorrectly inverted SuperPINDA pin

### DIFF
--- a/probes/super_pinda__btt_sb2209_usb.cfg
+++ b/probes/super_pinda__btt_sb2209_usb.cfg
@@ -1,5 +1,5 @@
 [probe]
-pin: ^!sb2209:gpio22
+pin: ^sb2209:gpio22
 x_offset: 38.6
 y_offset: 0.0
 samples: 3

--- a/probes/super_pinda__ldo_nitehawk_sb.cfg
+++ b/probes/super_pinda__ldo_nitehawk_sb.cfg
@@ -1,5 +1,5 @@
 [probe]
-pin: ^!nitehawk:gpio13
+pin: ^nitehawk:gpio13
 x_offset: 38.6
 y_offset: 0.0
 samples: 3


### PR DESCRIPTION
After seeing multiple people reporting that their SuperPINDA pin needed to be un-inverted in order to function, I'm fairly certain that the stock configs should have it not inverted. The `super_pinda__btt_sb2209_can.cfg` file is already correct, this patch brings the others in line.