### PR TITLE
Create Standard Extruder and Hotend Configs

### DIFF
--- a/extruders/clockwork_2.cfg
+++ b/extruders/clockwork_2.cfg
@@ -1,0 +1,6 @@
+[extruder]
+microsteps: 32
+full_steps_per_rotation: 200 # 200 for 1.8 degree, 400 for 0.9 degree
+rotation_distance: 22.6789511
+gear_ratio: 50:10
+max_extrude_only_distance: 150

--- a/extruders/galileo_2.cfg
+++ b/extruders/galileo_2.cfg
@@ -1,0 +1,9 @@
+[extruder]
+microsteps: 16
+full_steps_per_rotation: 200 # 200 for 1.8 degree, 400 for 0.9 degree
+rotation_distance: 47.088
+gear_ratio: 9:1
+max_extrude_only_distance: 150
+
+[tmc2209 extruder]
+run_current: 0.6

--- a/hotends/e3d_v6_revo.cfg
+++ b/hotends/e3d_v6_revo.cfg
@@ -1,0 +1,6 @@
+[extruder]
+min_temp: 0
+max_temp: 310
+sensor_type: ATC Semitec 104NT-4-R025H42G
+min_extrude_temp: 170
+max_extrude_cross_section: 2

--- a/printer.cfg.example
+++ b/printer.cfg.example
@@ -90,6 +90,13 @@ enable_force_move: True
 ##### Galileo 2
 #[include prusawire/extruders/galileo_2.cfg]
 
+[extruder]
+# The extruders have default rotation_distance values, but it should
+# be calibrated. See the included configuration files for start values.
+# Guide: https://ellis3dp.com/Print-Tuning-Guide/articles/extruder_calibration.html
+#rotation_distance: 0
+nozzle_diameter: 0.4
+
 #########################
 #### HOTENDS
 
@@ -144,9 +151,6 @@ damping_ratio_x: 0.037
 shaper_freq_y: 69.8
 shaper_type_y: 3hump_ei
 damping_ratio_y: 0.053
-
-[extruder]
-nozzle_diameter: 0.4
 
 #########################
 #### Rotation Distance

--- a/printer.cfg.example
+++ b/printer.cfg.example
@@ -82,6 +82,21 @@ enable_force_move: True
 #[include prusawire/probes/omron__btt_sb2209_usb.cfg]
 
 #########################
+#### EXTRUDERS
+
+##### Clockwork 2
+#[include prusawire/extruders/clockwork_2.cfg]
+
+##### Galileo 2
+#[include prusawire/extruders/galileo_2.cfg]
+
+#########################
+#### HOTENDS
+
+##### E3D V6, E3D Revo
+#[include prusawire/hotends/e3d_v6_revo.cfg]
+
+#########################
 #### FILAMENT SENSOR
 
 ##### LDO Nitehawk SB
@@ -132,16 +147,6 @@ damping_ratio_y: 0.053
 
 [extruder]
 nozzle_diameter: 0.4
-min_temp: 0
-max_temp: 310
-sensor_type: ATC Semitec 104NT-4-R025H42G # E3D Revo, Prusa E3D V6
-microsteps: 32
-full_steps_per_rotation: 200 # 200 for 1.8 degree, 400 for 0.9 degree
-rotation_distance: 22.6789511
-gear_ratio: 50:10 # Stealthburner CW2
-min_extrude_temp: 170
-max_extrude_only_distance: 150
-max_extrude_cross_section: 2
 
 #*# <---------------------- SAVE_CONFIG ---------------------->
 #*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.


### PR DESCRIPTION
Configurations for the Clockwork 2 and Galileo 2 have been created to reduce the setup needed for new users.

This is a non-breaking change since this is just adding new configurations that can be included, with the previous values not being maintained upstream.