### PR TITLE
BTT SKR Mini/Pico Kalico Compatibility

### DIFF
--- a/mainboards/btt_skr_mini_e3_v3.cfg
+++ b/mainboards/btt_skr_mini_e3_v3.cfg
@@ -20,6 +20,7 @@ endstop_pin: tmc2209_stepper_x:virtual_endstop
 
 [tmc2209 stepper_x]
 run_current: .3480291
+sense_resistor: 0.110
 diag_pin: ^PC0
 uart_address: 0
 uart_pin: PC11
@@ -34,6 +35,7 @@ endstop_pin: tmc2209_stepper_y:virtual_endstop
 
 [tmc2209 stepper_y]
 run_current: .3480291
+sense_resistor: 0.110
 diag_pin: ^PC1
 uart_address: 2
 uart_pin: PC11
@@ -47,6 +49,7 @@ enable_pin: !PB1
 
 [tmc2209 stepper_z]
 run_current: .3480291
+sense_resistor: 0.110
 diag_pin: ^PC2
 uart_address: 1
 uart_pin: PC11

--- a/mainboards/btt_skr_pico.cfg
+++ b/mainboards/btt_skr_pico.cfg
@@ -19,6 +19,7 @@ enable_pin: !gpio12
 endstop_pin: tmc2209_stepper_x:virtual_endstop
 
 [tmc2209 stepper_x]
+sense_resistor: 0.110
 uart_pin: gpio9
 tx_pin: gpio8
 uart_address: 0
@@ -34,6 +35,7 @@ enable_pin: !gpio7
 endstop_pin: tmc2209_stepper_y:virtual_endstop
 
 [tmc2209 stepper_y]
+sense_resistor: 0.110
 uart_pin: gpio9
 tx_pin: gpio8
 uart_address: 2
@@ -47,6 +49,7 @@ dir_pin: gpio28
 enable_pin: !gpio2
 
 [tmc2209 stepper_z]
+sense_resistor: 0.110
 uart_pin: gpio9
 tx_pin: gpio8
 uart_address: 1


### PR DESCRIPTION
In order to use Kalico, `sense_resistor` needs to be manually set since the default value is removed compared to Klipper. This allows for compatibility with Kalico for those who wish to run it.

**This is untested on the BTT SKR Pico**, but is tested on the BTT SKR Mini E3 V3.

This change is non-breaking since this is setting a default value in Klipper explicitly.