### PR TITLE
Set Default rotation_distance

### DIFF
--- a/mainboards/common_mainboard.cfg
+++ b/mainboards/common_mainboard.cfg
@@ -6,6 +6,10 @@ max_temp: 120
 [stepper_x]
 microsteps: 16
 full_steps_per_rotation: 200
+# Only valid for 20 teeth timing pulleys.
+# The stock MK3/MK4 ones use 16 teeth pulleys that must be changed or overwritten with a rotation_distance of 32.
+# Also apply to stepper_y and stepper_z.
+rotation_distance: 40
 position_endstop: -4
 position_max: 250
 position_min: -4
@@ -15,6 +19,7 @@ homing_retract_dist: 0
 [stepper_y]
 microsteps: 16
 full_steps_per_rotation: 200
+rotation_distance: 40
 position_endstop: -33
 position_max: 210
 position_min: -33
@@ -24,6 +29,7 @@ homing_retract_dist: 0
 [stepper_z]
 microsteps: 16
 full_steps_per_rotation: 200
+rotation_distance: 40
 step_pin: PB0
 dir_pin: PC5
 enable_pin: !PB1

--- a/printer.cfg.example
+++ b/printer.cfg.example
@@ -147,18 +147,17 @@ max_extrude_cross_section: 2
 #### Rotation Distance
 
 # If you are using stock MK3/MK4 timing pulleys (16 teeth) for 
-#your belts, you need to change rotation_distance to 32. 
+# your belts, uncomment the following to change rotation_distance to 32.
+# This must be kept after the mainboards section, which set a rotation_idstance of 40 (20 teeth).
 
-#If you are using 20 tooth timing pulleys, change rotation_distance to 40.
+#[stepper_x]
+#rotation_distance: 32
 
-[stepper_x]
-rotation_distance: 0
+#[stepper_y]
+#rotation_distance: 32
 
-[stepper_y]
-rotation_distance: 0
-
-[stepper_z]
-rotation_distance: 0
+#[stepper_z]
+#rotation_distance: 32
 
 #*# <---------------------- SAVE_CONFIG ---------------------->
 #*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.


### PR DESCRIPTION
This partly undoes [commit `67f251e`](https://github.com/Positron3D/prusawire-klipper-config/commit/67f251ebaf26a7b54dc3acc46818ed69185bc926) and re-adds the default `rotation_distance` of 40 (for 20 teeth timing pulleys). Comments about using 32 are provided to override this.