### PR TITLE
Expand PRINT_START Macro

### DIFF
--- a/macros/print_start_end.cfg
+++ b/macros/print_start_end.cfg
@@ -1,12 +1,40 @@
 [gcode_macro PRINT_START]
-#   Use PRINT_START for the slicer starting script - please customize for your slicer of choice
 gcode:
+#   Fetches data from your slicer.
+    {% set target_bed = params.BED|int %}
+    {% set target_extruder = params.EXTRUDER|int %}
+    {% set target_chamber = params.CHAMBER|default("45")|int %}
+    {% set target_chamber_minimal = params.CHAMBER_MINIMAL|default("0")|int %}
+    {% set target_chamber_wait = [target_chamber, target_chamber_minimal]|select(">", 0)|min|default(0) %}
+
+#   Heat up bed and nozzle initially and wait.
+    SET_HEATER_TEMPERATURE HEATER=extruder TARGET=170
+    SET_HEATER_TEMPERATURE HEATER=heater_bed TARGET={target_bed}
+    TEMPERATURE_WAIT sensor=heater_bed minimum={target_bed}
+    TEMPERATURE_WAIT sensor=extruder minimum=150
+    
+#   Home axes.
     G28                            ; home all axes
     G90                            ; absolute positioning
     G1 Z20 F3000                   ; move nozzle away from bed
 
+#   Perform adaptive bed mesh.
+    BED_MESH_CALIBRATE ADAPTIVE=1
+    G0 X2.5 Y-10 F3000             ; Go to front
+
+#   Heat nozzle to print temperature.
+    SET_HEATER_TEMPERATURE HEATER=extruder TARGET={target_extruder}
+    TEMPERATURE_WAIT SENSOR=extruder MINIMUM={target_extruder}
+
+#   Create prime line.
+    G0 Z0.15                       ; Drop to bed
+    M83                            ; Set extruder to relative mode
+    G1 X45 E15 F500                ; Extrude 25mm of filament in a 4cm line
+    G1 E-0.5 F400                  ; Retract a little
+    G1 X85 F4000                   ; Quickly wipe away from the filament line
+    G1 Z0.3                        ; Raise and begin printing.
+
 [gcode_macro PRINT_END]
-#   Use PRINT_END for the slicer ending script - please customize for your slicer of choice
 gcode:
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder


### PR DESCRIPTION
Following the current Voron profile recommendations of putting everything in the `PRINT_START` macro instead of the Start G-Code. This expanded `PRINT_START` includes the waiting for temperature, homing (existing), adaptive mesh, and prime line previously part of the slicer profiles.

**This is a breaking change for the slicer profiles**, since this will duplicate the bed mesh, waiting for temperature, and prime line.