### PR TITLE
Retract Nozzle After Load and Print Finish

### DIFF
--- a/macros/filament_load_unload.cfg
+++ b/macros/filament_load_unload.cfg
@@ -1,3 +1,6 @@
+[extruder]
+min_extrude_temp: 0 # Set to 0 to allow for cold unloads.
+
 [gcode_macro M600]
 description: Color change
 gcode:
@@ -15,19 +18,33 @@ gcode:
     G1 E-50 F1000
     RESTORE_GCODE_STATE NAME=M600_state
 
+[gcode_macro _FILAMENT_RETRACT]
+description: Unloads filament from the nozzle
+variable_retract_distance: 8
+gcode:
+  M83                           ; set extruder to relative mode
+  G1 E-{retract_distance} F1800 ; quickly retract a small amount
+  M400                          ; wait for moves to finish
+
+[gcode_macro _FILAMENT_PRIME]
+description: Loads filament from the nozzle
+variable_prime_distance: 8
+gcode:
+  M83                           ; set extruder to relative mode
+  G1 E{prime_distance} F3600    ; quickly extrude a small amount
+  M400                          ; wait for moves to finish
+
+
 [gcode_macro UNLOAD_FILAMENT]
 description: Unloads filament from the toolhead
 gcode:
-    {% set EXTRUDER_TEMP = params.TEMP|default(230)|int %}
     CHOME
     G91                         ; relative positioning
     G1 Z20                      ; move nozzle upwards
     FRONT                       ; move the toolhead to the front
-    LOGO_PENDING
-    M109 S{EXTRUDER_TEMP}       ; heat up the hotend
     LOGO_READY
     M83                         ; set extruder to relative mode
-    G1 E-8 F1800                ; quickly retract a small amount to elimate stringing
+    G1 E-8 F1800                ; quickly retract a small amount to eliminate stringing
     G4 P200                     ; pause for a short amount of time
     G1 E-50 F300                ; retract slowly the rest of the way
     G1 E-20 F300
@@ -44,8 +61,9 @@ gcode:
     M109 S{EXTRUDER_TEMP}       ; heat up the hotend
     LOGO_READY
     M83                         ; set extruder to relative mode
-    G1 E50 F300                 ; extrude slowlyL
+    G1 E50 F300                 ; extrude slowly
     G1 E50 F300
     M400                        ; wait for moves to finish
+    _FILAMENT_RETRACT
     M117 Load Complete!
     LOGO_OFF

--- a/macros/print_start_end.cfg
+++ b/macros/print_start_end.cfg
@@ -27,6 +27,7 @@ gcode:
     TEMPERATURE_WAIT SENSOR=extruder MINIMUM={target_extruder}
 
 #   Create prime line.
+    _FILAMENT_PRIME
     G0 Z0.15                       ; Drop to bed
     M83                            ; Set extruder to relative mode
     G1 X45 E15 F500                ; Extrude 25mm of filament in a 4cm line
@@ -37,8 +38,7 @@ gcode:
 [gcode_macro PRINT_END]
 gcode:
     M400                           ; wait for buffer to clear
-    G92 E0                         ; zero the extruder
-    G1 E-4.0 F3600                 ; retract filament
+    _FILAMENT_RETRACT              ; retract filament
     G91                            ; relative positioning
 
 #   Get Boundaries
@@ -71,3 +71,11 @@ gcode:
     M107                           ; turn off fan
     G90                            ; absolute positioning
     G0 X60 Y{max_y} F3600          ; park nozzle at rear
+
+[gcode_macro CANCEL_PRINT]
+description: Cancel the running print
+rename_existing: CANCEL_PRINT_BASE
+gcode:
+  PRINT_END
+  TURN_OFF_HEATERS
+  CANCEL_PRINT_BASE


### PR DESCRIPTION
Following a similar setup to the Prusa printers, this adds retracting the filament after it finishes loading and print finishing. This allows filament to be unloaded without heating up the extruder.

This also adds running `PRINT_END` when a print is canceled.